### PR TITLE
NEW: Don't display col-buttons if reordering is active

### DIFF
--- a/css/GridFieldGalleryTheme.css
+++ b/css/GridFieldGalleryTheme.css
@@ -55,5 +55,7 @@
           border: none;
           background-color: #fff;
           border: 1px solid #ccc; }
+  .cms .cms-edit-form table.ss-gridfield-table.galleryTheme.dragSorting td.col-buttons {
+    display: none !important; }
 
 /* .cms table.ss-gridfield-table */

--- a/css/GridFieldGalleryTheme.scss
+++ b/css/GridFieldGalleryTheme.scss
@@ -80,4 +80,11 @@
       }/* td */
     }/* tr.ss-gridfield-item */
   }/* tbody.ss-gridfield-items */
+
+  &.dragSorting
+  {
+    td.col-buttons {
+      display: none !important;
+    }
+  }
 }/* .cms table.ss-gridfield-table */


### PR DESCRIPTION
This removes the col-buttons from the view, if sortable is activated.
This enables a better sorting experience, without accidentally clicking edit/delete while sorting...

Best regards,
s-m
