### PR TITLE
Detect missing image and prevent error that breaks CMS

### DIFF
--- a/code/GridFieldGalleryTheme.php
+++ b/code/GridFieldGalleryTheme.php
@@ -66,8 +66,12 @@ class GridFieldGalleryTheme implements GridField_HTMLProvider, GridField_ColumnP
       {
         if ( $previewObj instanceof Image )
         {
-          $url = $previewObj->CroppedImage( 150, 150 )->URL;
-          if ($url) $imgFile = $url;
+          $croppedImage = $previewObj->CroppedImage( 150, 150 );
+          if ($croppedImage)
+          {
+            $url = $croppedImage->URL;
+            if ($url) $imgFile = $url;
+          }
         }
         else if ( $previewObj instanceof File )
         {


### PR DESCRIPTION
Was getting this error in my dev environment when the image didn't exist on disk, making the CMS unusable. It needs to fail more gracefully:
<div class="info notice"><h1>[Notice] Trying to get property of non-object</h1><h3>GET /index.php/admin/pages/edit/show/61</h3><p>Line <strong>69</strong> in <strong>/var/www/site.co.nz/gridfield-gallery-theme/code/GridFieldGalleryTheme.php</strong></p></div>