### PR TITLE
FIX: Don't assume SS4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "url": "git@github.com:colymba/GridFieldGalleryTheme.git"
   }],
 	"require": {
-    "silverstripe/cms": ">=3.0"
-	}
+    "silverstripe/cms": "^3.0"
+	
 }


### PR DESCRIPTION
Major versions won't automatically work, and so I've amended the composer requirements
not to allow SS4.

This will also ensure that addons.silverstripe.org correctly reports which modules
work with SS4.